### PR TITLE
Feat/#123: 구현 버블껌 BGM 재생

### DIFF
--- a/MC3Team18/MC3Team18/View/BubbleGum/AudioStreamManager.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/AudioStreamManager.swift
@@ -19,6 +19,8 @@ class AudioStreamManager {
     private var resultObserver = AudioStreamObserver()
     
     init() {
+        bgmStop()
+        
         engine = AVAudioEngine()
         
         //Getting the built-in microphone audio bus and saving its format
@@ -39,6 +41,16 @@ class AudioStreamManager {
         streamAnalyzer = SNAudioStreamAnalyzer(format: micInputFormat)
         
         classifierSetup()
+        
+        bgmStart()
+    }
+    
+    private func bgmStop() {
+        MusicPlayer.shared.stopBackgroundMusic()
+    }
+    
+    private func bgmStart() {
+        MusicPlayer.shared.startBackgroundMusic(musicName: "BubbleGumMusicDummy")
     }
     
     public func resultObservation(with observer: SNResultsObserving) {

--- a/MC3Team18/MC3Team18/View/HomeView.swift
+++ b/MC3Team18/MC3Team18/View/HomeView.swift
@@ -41,15 +41,17 @@ struct HomeView: View {
                 }
                 .statusBarHidden()
                 .ignoresSafeArea()
+                .onAppear {
+                    MusicPlayer.shared.stopBackgroundMusic()
+                    MusicPlayer.shared.startBackgroundMusic(musicName: "MainScreenMusicDummy")
+                }
             case .bubbleGum:
                 BubbleGumStatusView(gameSelection: $gameSelected)
             case .chagok:
                 ChagokGameView(gameSelection: $gameSelected)
             }
         }
-        .onAppear {
-        MusicPlayer.shared.startBackgroundMusic(musicName: "MainScreenMusicDummy")
-        }
+        
     }
 }
 


### PR DESCRIPTION
#### close #123 

## ✅ What Did You Do
- [x] 버블껌 게임 진입 시 BGM 재생
- [x] 홈화면 이동 시 홈 BGM 재생

***

## 🎸 ETC
- 버블껌 게임 선택을 하면 AudioStreamManager 초기화가 시작되는데, 이 초기화 과정과 꼬여서(?) 재생이 이상하게 됐던 것 같습니다.
 init() 내부 코드의 시작과 끝 부분에 BGM 종료와 시작 코드를 넣어 해결했습니다. 🫠
- HomeView 진입 시 BGM이 재생되던 코드를 BGM을 종료한 후 재생하도록 수정하여
게임을 진행하다 HomeView로 돌아왔을 경우 MainBGM이 아닌 게임 각각의 BGM이 재생되던 잇쓔를 해결하였습니다.