### PR TITLE
Bug/#176 : 수정 풍선껌 BestScore쪽 초 소수점 단위로

### DIFF
--- a/MC3Team18/MC3Team18/Global/Components/Menu/MenuBottomScoresView.swift
+++ b/MC3Team18/MC3Team18/Global/Components/Menu/MenuBottomScoresView.swift
@@ -1,24 +1,20 @@
 //
-//  MenuBottomScoresView.swift
-//  MC3Team18
+// MenuBottomScoresView.swift
+// MC3Team18
 //
-//  Created by ChoiYujin on 2023/07/21.
+// Created by ChoiYujin on 2023/07/21.
 //
 
 import SwiftUI
 
 struct MenuBottomScoresView: View {
-    
     //TODO: Star 게임 만들어지면 바꿀 것
     var bestScoreArray : [String] = [ String(UserDefaults.standard.integer(forKey: "chagokScore")), UserDefaults.standard.string(forKey: "BubbleScore") ?? "0", "12500"]
-    var bestRecordArray : [Int] = [
-        UserDefaults.standard.integer(forKey: "chagokScore") / 1500, Int(UserDefaults.standard.string(forKey: "BubbleScore") ?? "0") ?? 0 / 1000, 15
+    var bestRecordArray : [String] = [
+        String(UserDefaults.standard.integer(forKey: "chagokScore") / 1500), String(format: "%.1f", Double(UserDefaults.standard.string(forKey: "BubbleScore") ?? "0")! / 1000.0), "15"
     ]
     var bestUnitArray : [String] = ["줄", "초", "개"]
     var bestNameArray : [String] = ["차곡차곡", "풍선껌불기", "별따먹기"]
-    
-    
-    
     var body: some View {
         VStack {
             HStack {
@@ -29,7 +25,6 @@ struct MenuBottomScoresView: View {
             .padding(.leading, 34)
             Spacer().frame(maxHeight: 13)
             HStack(spacing: -3) {
-                
                 ForEach(Array(BestScoreImage.allCases.enumerated()), id: \.element) { index, item in
                     Image("\(item.rawValue)")
                         .resizable()
@@ -43,7 +38,7 @@ struct MenuBottomScoresView: View {
                                         .pretendardBold14()
                                         .padding(.bottom, 10)
                                         .frame(maxWidth: .infinity, alignment: .leading)
-
+                                    
                                     Text("\(bestScoreArray[index])")
                                         .pretendardExtraLight11()
                                         .padding(.bottom, 2)
@@ -67,7 +62,6 @@ struct MenuBottomScoresView: View {
             }
             .frame(minHeight: 155)
             .padding(.horizontal, 14)
-            
         }
     }
 }


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #176 

## ✅ What Did You Do
- [x] BestScore쪽 소수점 단위로 표시하기

***

## 🎸 ETC
- BestScore와 같이 천단위 점수로 나오는 것을 초단위로 바꾸었습니다.