### PR TITLE
Bug/#228: 수정 버블버블, 반짝반짝 게임 AudioEngine 종료

### DIFF
--- a/MC3Team18/MC3Team18/View/BubbleGum/AudioStreamManager.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/AudioStreamManager.swift
@@ -107,7 +107,7 @@ class AudioStreamManager {
         }
     }
     
-    public func installTap() {
+    private func installTap() {
         guard let engine = engine else {
             fatalError("Failed to retrieve audio engine")
         }
@@ -121,7 +121,7 @@ class AudioStreamManager {
         engine.inputNode.installTap(onBus: inputBus, bufferSize: 4000, format: micInputFormat, block: analyzeAudio(buffer:at:))
     }
     
-    public func removeTap() {
+    private func removeTap() {
         guard let engine = engine else {
             fatalError("Failed to retrieve audio engine")
         }
@@ -129,6 +129,15 @@ class AudioStreamManager {
             fatalError("Failed to retrieve input bus")
         }
         engine.inputNode.removeTap(onBus: inputBus)
+    }
+    
+    public func startAudioStream() {
+        startEngine()
+        installTap()
+    }
+    public func stopAudioStream() {
+        removeTap()
+        engine?.stop()
     }
     
     public func getStreamPublisher() -> Optional<SNAudioStreamAnalyzer>.Publisher {

--- a/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumGameOverView.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumGameOverView.swift
@@ -14,7 +14,8 @@ struct BubbleGumGameOverView: View {
     @Binding var bubbleHighScore: String
     @Binding var isBestScore: Bool
     @AppStorage("BalloonMissionSuccess") var BalloonMissionSuccess: Bool = false
-    
+    var streamManager: AudioStreamManager
+
     var body: some View {
         ZStack {
             Color.black.opacity(0.75).ignoresSafeArea()
@@ -71,6 +72,7 @@ struct BubbleGumGameOverView: View {
                 HStack(){
                     Button {
                         withAnimation(.easeOut(duration: 0.3)) {
+                            streamManager.stopAudioStream()
                             gameSelection = .none
                         }
                     } label: {
@@ -104,7 +106,7 @@ struct BubbleGumGameOverView: View {
 
 struct BubbleGumGameOverView_Previews: PreviewProvider {
     static var previews: some View {
-        BubbleGumGameOverView(bubbleGumStatus: .constant(.gameover), gameSelection: .constant(.bubbleGum), score: .constant("23.0"), bubbleHighScore: .constant("22.0"), isBestScore: .constant(true))
+        BubbleGumGameOverView(bubbleGumStatus: .constant(.gameover), gameSelection: .constant(.bubbleGum), score: .constant("23.0"), bubbleHighScore: .constant("22.0"), isBestScore: .constant(true), streamManager: AudioStreamManager())
     }
 }
 

--- a/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumGameView.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumGameView.swift
@@ -109,7 +109,7 @@ struct BubbleGumGameView: View {
     
     private func endGame() {
         HapticManager.instance.notification(type: .error)
-        streamManager.removeTap()
+        streamManager.stopAudioStream()
         bubbleGumStatus = .gameover
         SoundEffectPlayer.shared.stopSoundEffect()
 //        SoundEffectPlayer.shared.playSoundEffect(soundName: SoundNames.bubblegumGameOverEffect.rawValue)

--- a/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumStatusView.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumStatusView.swift
@@ -59,7 +59,7 @@ struct BubbleGumStatusView: View {
             case .game:
                 BubbleGumGameView(bubbleGumStatus: $bubbleGumStatus, observer: observer, streamManager: streamManager, currentExpressionIndex: $currentExpressionIndex, backgroundOffset: $backgroundOffset, scale: $scale, score: $score, bubbleHighScore: $bubbleHighScore, offsetX: $offsetX, offsetY: $offsetY, isBestScore: $isBestScore)
             case .gameover:
-                BubbleGumGameOverView(bubbleGumStatus: $bubbleGumStatus, gameSelection: $gameSelection, score: $score, bubbleHighScore: $bubbleHighScore, isBestScore: $isBestScore)
+                BubbleGumGameOverView(bubbleGumStatus: $bubbleGumStatus, gameSelection: $gameSelection, score: $score, bubbleHighScore: $bubbleHighScore, isBestScore: $isBestScore, streamManager: streamManager)
             }
             
         }

--- a/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumWaitingView.swift
+++ b/MC3Team18/MC3Team18/View/BubbleGum/BubbleGumWaitingView.swift
@@ -30,6 +30,7 @@ struct BubbleGumWaitingView: View {
             .padding(.bottom, 70)
             .onTapGesture {
                 withAnimation(.easeOut(duration: 0.3)) {
+                    streamManager.stopAudioStream()
                     gameSelection = .none
                 }
             }
@@ -39,7 +40,7 @@ struct BubbleGumWaitingView: View {
                 .foregroundColor(.white)
                 .shadow(color: .black.opacity(0.12), radius: 12, x: 1, y: 2)
                 .onAppear {
-                    streamManager.installTap()
+                    streamManager.startAudioStream()
                 }
                 .onChange(of: observer.topResults) { _ in
                     print("Start")

--- a/MC3Team18/MC3Team18/View/Star/StarAudioStreamManager.swift
+++ b/MC3Team18/MC3Team18/View/Star/StarAudioStreamManager.swift
@@ -50,7 +50,6 @@ class StarAudioStreamManager: ObservableObject {
     }
     
     private func bgmStart() {
-        //TODO: 스타 bgm 연결
         MusicPlayer.shared.startBackgroundMusic(musicName: SoundNames.banzzakBGM.rawValue)
     }
     
@@ -75,7 +74,6 @@ class StarAudioStreamManager: ObservableObject {
     private func classifierSetup() {
         let defaultConfig = MLModelConfiguration()
         let soundClassifier = try? Trill_35_05_50(configuration: defaultConfig)
-         
         guard let soundClassifier = soundClassifier else {
             fatalError("Could not instantiate sound classifier")
         }
@@ -107,7 +105,7 @@ class StarAudioStreamManager: ObservableObject {
         }
     }
     
-    public func installTap() {
+    private func installTap() {
         guard let engine = engine else {
             fatalError("Failed to retrieve audio engine")
         }
@@ -121,7 +119,7 @@ class StarAudioStreamManager: ObservableObject {
         engine.inputNode.installTap(onBus: inputBus, bufferSize: 4000, format: micInputFormat, block: analyzeAudio(buffer:at:))
     }
     
-    public func removeTap() {
+    private func removeTap() {
         guard let engine = engine else {
             fatalError("Failed to retrieve audio engine")
         }
@@ -129,6 +127,15 @@ class StarAudioStreamManager: ObservableObject {
             fatalError("Failed to retrieve input bus")
         }
         engine.inputNode.removeTap(onBus: inputBus)
+    }
+    
+    public func startAudioStream() {
+        startEngine()
+        installTap()
+    }
+    public func stopAudioStream() {
+        removeTap()
+        engine?.stop()
     }
     
     public func getStreamPublisher() -> Optional<SNAudioStreamAnalyzer>.Publisher {

--- a/MC3Team18/MC3Team18/View/Star/StarGameOverView.swift
+++ b/MC3Team18/MC3Team18/View/Star/StarGameOverView.swift
@@ -79,7 +79,7 @@ struct StarGameOverView: View {
                             secondsx4 = 120
                             starSKScene.score = 0
                             gameSelection = .none
-                            streamManager.removeTap()
+                            streamManager.stopAudioStream()
                         }
                     } label: {
                         starGameOverViewButton(systemName: "house", text: "Home")

--- a/MC3Team18/MC3Team18/View/Star/StarGameView.swift
+++ b/MC3Team18/MC3Team18/View/Star/StarGameView.swift
@@ -25,7 +25,7 @@ struct StarGameView: View {
     init(gameSelection: Binding<GameSelection>) {
         _gameSelection = gameSelection
         streamManager.resultObservation(with: observer)
-        streamManager.installTap()
+        streamManager.startAudioStream()
         print("ONONINIT")
     }
     

--- a/MC3Team18/MC3Team18/View/Star/StarPauseView.swift
+++ b/MC3Team18/MC3Team18/View/Star/StarPauseView.swift
@@ -42,7 +42,7 @@ struct StarPauseView: View {
                         secondsx4 = 120
                         gameSelection = .none
                         starSKScene.score = 0
-                        streamManager.removeTap()
+                        streamManager.stopAudioStream()
                     }
                 } label: {
                     starPauseButton(systemName: "house", text: "Home")


### PR DESCRIPTION
#### close #228

## ✅ What Did You Do
- [x] 버블버블, 반짝반짝 게임의 AudioEngine 종료

***

## 🎸 ETC
- 기존의 removeTap()으로는 마이크 사용이 멈춰지지 않아 engine.stop()을 추가하였습니다.