### PR TITLE
UI/#271: 수정 Chalk 레이아웃

### DIFF
--- a/MC3Team18/MC3Team18/View/Chagok/ChagokGameView.swift
+++ b/MC3Team18/MC3Team18/View/Chagok/ChagokGameView.swift
@@ -85,9 +85,9 @@ struct ChagokGameView: View {
                     }
                 }
                 .foregroundColor(.white)
-                .padding(.bottom, 5)
+                .padding(.bottom, 12)
                 .frame(height: 29)
-                HStack(spacing: 4) {
+                HStack(spacing: 8) {
                     Image(systemName: "hourglass")
                         .resizable()
                         .scaledToFit()
@@ -135,13 +135,14 @@ struct ChagokGameView: View {
                             }
                             .frame(width: 150, height: 300)
                             .opacity(isRightCupVisiable ? 1 : 0)
-                            .offset(y: 8)
+                            .offset(y: 40)
                         }
                     Rectangle().frame(width: 155, height: 360).cornerRadius(12)
                         .overlay {
                             
                             SpriteView(scene: chagokScene, options: [.allowsTransparency])
                                 .frame(width: 150, height: 300)
+                                .offset(y: 33)
                         }
                 }
                 .foregroundColor(.white.opacity(0.4))
@@ -161,6 +162,7 @@ struct ChagokGameView: View {
                             Text("Tap to start")
                                 .pretendardSemiBold20()
                                 .foregroundColor(.white)
+                                .shadow(color:.black.opacity(0.25), radius: 8, x: 1, y: 2)
                         }
                         .opacity(tapToStartOpacity)
                         .padding(.bottom, 20)

--- a/MC3Team18/MC3Team18/View/Chagok/ChagokPauseView.swift
+++ b/MC3Team18/MC3Team18/View/Chagok/ChagokPauseView.swift
@@ -104,8 +104,10 @@ extension ChagokPauseView {
                 VStack(spacing:9){
                     Image(systemName: systemName)
                         .foregroundColor(.white)
+                        .frame(width: 24, height: 24)
                     Text(text)
                         .foregroundColor(.white)
+                            .pretendardBold20()
                     
                 }
             }


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #271

## ✅ What Did You Do
- [x] 게임뷰 컵스택 위치 조정(아래로)
- [x] 게임뷰 Tap to Start 부분 그림자 추가
- [x] 점수 Progress Bar 간격 조정
- [x] 모래시계, Progress Bar 사이 간격 조정
- [x] PauseView 버튼 이미지(홈) 사이즈 및 폰트 수정

***

## 🎸 ETC