### PR TITLE
Feat/#273 노란컵, 보라컵 동시에 판정 발생하지 않게 수정

### DIFF
--- a/MC3Team18/MC3Team18/View/Chagok/ChagokSKScene.swift
+++ b/MC3Team18/MC3Team18/View/Chagok/ChagokSKScene.swift
@@ -50,7 +50,7 @@ class ChagokSKScene: SKScene, ObservableObject {
             return
         }
         
-        if mouthA > 0.4 && mouthI > 0.4 {
+        if mouthA > 0.45 && mouthI > 0.45 {
             if mouthState != MouthState.a && leftCupStack[self.currentIndex] == CupName.RedCup {
                 dropbox(cupname: CupName.RedCup)
                 mouthState = MouthState.a
@@ -58,7 +58,7 @@ class ChagokSKScene: SKScene, ObservableObject {
             }
         }
         
-        if mouthE > 0.5{
+        if mouthE > 0.5 && mouthU < 0.5{
             if mouthState != MouthState.e && leftCupStack[self.currentIndex] == CupName.YellowCup {
                 dropbox(cupname: CupName.YellowCup)
                 mouthState = MouthState.e
@@ -66,7 +66,7 @@ class ChagokSKScene: SKScene, ObservableObject {
             }
         }
         
-        if mouthI > 0.5 && mouthA < 0.15{
+        if mouthI > 0.5 && mouthA < 0.15 {
             if mouthState != MouthState.i && leftCupStack[self.currentIndex] == CupName.GreenCup {
                 dropbox(cupname: CupName.GreenCup)
                 mouthState = MouthState.i
@@ -82,7 +82,7 @@ class ChagokSKScene: SKScene, ObservableObject {
             }
         }
         
-        if mouthU > 0.65 && mouthI < 0.5 && mouthA < 0.25 && leftCupStack[self.currentIndex] == CupName.PinkCup{
+        if mouthU > 0.65 && mouthI < 0.5 && mouthA < 0.25 && mouthE < 0.25 && leftCupStack[self.currentIndex] == CupName.PinkCup{
             if mouthState != MouthState.u{
                 dropbox(cupname: CupName.PinkCup)
                 mouthState = MouthState.u


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #닫을 이슈 번호 작성

## ✅ What Did You Do
- [x] 노란컵, 보라컵 동시에 판정 발생하지 않게 수정

***

## 🎸 ETC
- 100% 동시에 판정이 발생하지 않게 하는 것은 불가능했습니다. 사람 표정에 따라 미묘하게 둘다 인식되는 각도가 있더라고요.
- 동시판정이 발생하는 경우를 크게 줄였다.. 정도의 결과물이 나왔습니다.