### PR TITLE
UI/#316 수정 GameOverView Button 레이아웃

### DIFF
--- a/MC3Team18/MC3Team18/View/Banjjak/BanjjakGameOverView.swift
+++ b/MC3Team18/MC3Team18/View/Banjjak/BanjjakGameOverView.swift
@@ -89,7 +89,6 @@ struct BanjjakGameOverView: View {
                 Spacer()
                 
                 HStack(spacing: 40){
-                    
                     Button {
                         withAnimation(.easeOut(duration: 0.3)) {
                             isBestScore = false
@@ -122,15 +121,8 @@ struct BanjjakGameOverView: View {
                     }
                     .buttonStyle(GameOverButtonStyle(gameSelection: .banjjak))
                 }
+                .padding(.bottom, 83)
             }
-// <<<<<<< UI/#307
-//                 }.padding(.horizontal, 62)
-//             }.padding(.bottom, 83)
-// =======
-//                     .buttonStyle(GameOverButtonStyle(gameSelection: .banjjak))
-//                 }
-//             }
-// >>>>>>> develop
         }
         .opacity(gameoverOpacity)
         .statusBarHidden()
@@ -165,7 +157,7 @@ struct BanjjakGameOverView: View {
     
     func check() {
         //TODO: hasDailyMissionPrizeBeenShown 다음날인 경우 false
-        if hasDailyMissionPrizeBeenShown == true { return } // 한번 보여줬으면 안보여주기
+        if hasDailyMissionPrizeBeenShown == true { return }
         
         if ChagokMissionSuccess && BubbleMissionSuccess && BanjjakMissionSuccess {
             showDailyPrize = true
@@ -174,11 +166,11 @@ struct BanjjakGameOverView: View {
     }
 }
 
-//struct BanjjakGameOverView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        BanjjakGameOverView(banjjakScore: .constant(0), isBestScore: true, banjjakStatus: .constant(.gameover), gameSelection: .constant(.banjjak))
-//    }
-//}
+struct BanjjakGameOverView_Previews: PreviewProvider {
+    static var previews: some View {
+        BanjjakGameOverView(banjjakStatus: .constant(.gameover), secondsx4: .constant(0), gameSelection: .constant(.banjjak), isBestScore: .constant(true), banjjakScore: .constant("0"))
+    }
+}
 
 extension BanjjakGameOverView {
     func banjjakGameOverViewButton(systemName: String, text: String) -> some View {

--- a/MC3Team18/MC3Team18/View/Banjjak/BanjjakGameView.swift
+++ b/MC3Team18/MC3Team18/View/Banjjak/BanjjakGameView.swift
@@ -60,7 +60,6 @@ struct BanjjakGameView: View {
                     //TODO: ScaleEffect
                     Spacer()
                     Button {
-                        //TODO: banjjakState = 일시정지
                         banjjakSKScene.isPaused = true
                         banjjakStatus = BanjjakStatus.pause
                     } label: {

--- a/MC3Team18/MC3Team18/View/Banjjak/BanjjakPauseView.swift
+++ b/MC3Team18/MC3Team18/View/Banjjak/BanjjakPauseView.swift
@@ -29,13 +29,11 @@ struct BanjjakPauseView: View {
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                         banjjakStatus = .game
                     }
-                    // TODO: 화면 업데이트 중지 및 재개 기능??
                 } label: {
                     GameButtonLabel(width: 167, height: 134, systemName: "play", buttonText: "Continue")
                 }
                 .buttonStyle(PauseButtonStyle(gameSelection: .banjjak))
                 Button {
-                    // TODO: 게임 리셋, 화면 이동(애니메이션)
                     withAnimation(.easeOut(duration: 0.3)) {
                         banjjakSKScene.isPaused = false
                         banjjakSKScene.removeAllChildren()
@@ -49,9 +47,7 @@ struct BanjjakPauseView: View {
                     pauseGlassMorphicButtonLabel(systemName: "house", text: "Home", width: 167, height: 134)
                 }
                 
-                Button {
-                    // TODO: 게임 리셋
-                    
+                Button {                    
                     withAnimation(.easeOut(duration: 0.3)) {
                         banjjakSKScene.isPaused = false
                         banjjakSKScene.removeAllChildren()

--- a/MC3Team18/MC3Team18/View/Banjjak/BanjjakTutorialView.swift
+++ b/MC3Team18/MC3Team18/View/Banjjak/BanjjakTutorialView.swift
@@ -23,7 +23,6 @@ struct BanjjakTutorialView: View {
                 HStack {
                     Spacer()
                     Button {
-                        //TODO: 튜토리얼 상태 저장, 게임 업데이트=false
                         isBanjjakTutorialDisabled = isChecked
                         withAnimation(.easeOut(duration: 0.2)) {
                             tutorialOpacity = 0

--- a/MC3Team18/MC3Team18/View/Bubble/BubbleGameOverView.swift
+++ b/MC3Team18/MC3Team18/View/Bubble/BubbleGameOverView.swift
@@ -61,7 +61,6 @@ struct BubbleGameOverView: View {
                             .pretendardLight32()
                             .foregroundColor(.white)
                     }
-                    
                     Text(score)
                         .postNoBillsJaffnaRegular64()
                         .foregroundColor(.white)
@@ -80,16 +79,9 @@ struct BubbleGameOverView: View {
                     } else {
                         GameCoinPrizeView()
                     }
-                    
                 }
-                
-
                 Spacer()
-                HStack(){
-// =======
-//                 HStack(spacing: 40){
-                    
-// >>>>>>> develop
+                HStack(spacing: 40){
                     Button {
                         withAnimation(.easeOut(duration: 0.3)) {
                             streamManager.stopAudioStream()
@@ -99,10 +91,6 @@ struct BubbleGameOverView: View {
                         gameOverGlassMorphicButtonLabel(systemName: "house", text: "Home", width: 136, height: 96)
                     }
 
-                    Spacer()
-// =======
-                    
-// >>>>>>> develop
                     Button {
                         bubbleStatus = .waiting
                     } label: { 
@@ -110,16 +98,11 @@ struct BubbleGameOverView: View {
                     }
                     .buttonStyle(GameOverButtonStyle(gameSelection: .bubble))
                 }
-// =======
-//                 Spacer().frame(minHeight: 120)
-// >>>>>>> develop
             }
-            .padding(.horizontal, 26)
             .padding(.top, isBestScore ? 108 : 158)
             .padding(.bottom, 83)
         }
         .ignoresSafeArea()
-        .padding(.horizontal, 36)
         .opacity(gameoverOpacity)
         .onAppear {
             check()
@@ -136,7 +119,7 @@ struct BubbleGameOverView: View {
     
     func check() {
         //TODO: hasDailyMissionPrizeBeenShown 다음날인 경우 false
-        if hasDailyMissionPrizeBeenShown == true { return } // 한번 보여줬으면 안보여주기
+        if hasDailyMissionPrizeBeenShown == true { return }
         
         if ChagokMissionSuccess && BubbleMissionSuccess && BanjjakMissionSuccess {
             showDailyPrize = true

--- a/MC3Team18/MC3Team18/View/Bubble/BubbleGameView.swift
+++ b/MC3Team18/MC3Team18/View/Bubble/BubbleGameView.swift
@@ -36,9 +36,6 @@ struct BubbleGameView: View {
     @State var gameOpacity: Double = 0
     
     @AppStorage("bubbleScore") var bubbleScore: String = "0"
-    
-//    @AppStorage("BubbleMissionSuccess") var BubbleMissionSuccess: Bool = false
-
 
     var body: some View {
         ZStack {

--- a/MC3Team18/MC3Team18/View/Chagok/ChagokGameOverView.swift
+++ b/MC3Team18/MC3Team18/View/Chagok/ChagokGameOverView.swift
@@ -86,7 +86,6 @@ struct ChagokGameOverView: View {
                 Spacer()
                 
                 HStack(spacing: 40){
-                    
                     Button {
                         isBestScore = false
                         withAnimation(.easeOut(duration: 0.3)) {
@@ -95,7 +94,6 @@ struct ChagokGameOverView: View {
                     } label: {
                         gameOverGlassMorphicButtonLabel(systemName: "house", text: "Home", width: 136, height: 96)
                     }
-                    
                     Button {
                         // 게임 상태 초기화 만들기
                         chagokScene.chagokScore = 0
@@ -153,7 +151,7 @@ struct ChagokGameOverView: View {
     }
     func check() {
         //TODO: hasDailyMissionPrizeBeenShown 다음날인 경우 false
-        if hasDailyMissionPrizeBeenShown == true { return } // 한번 보여줬으면 안보여주기
+        if hasDailyMissionPrizeBeenShown == true { return }
         
         if ChagokMissionSuccess && BubbleMissionSuccess && BanjjakMissionSuccess {
             showDailyPrize = true


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #316 

## ✅ What Did You Do
- [x] GameOverView Button 레이아웃 수정(spacing)
- [ ] 공백 및 주석 삭제
***

## 🎸 ETC
- 게임 3개의 게임오버 화면의 하단 버튼 레이아웃을 spacing을 40으로 통일합니다.