### PR TITLE
Feat/#321 차곡차곡 1줄 클리어 시 추가시간 3초 -> 1초로 하향

### DIFF
--- a/MC3Team18/MC3Team18/View/Chagok/ChagokGameView.swift
+++ b/MC3Team18/MC3Team18/View/Chagok/ChagokGameView.swift
@@ -267,7 +267,7 @@ struct ChagokGameView: View {
             if newValue {
                 withAnimation(.easeOut(duration: 0.3)) {
                     scoreScale = 1.3
-                    secondsx4 += 12
+                    secondsx4 += 4
                 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                     withAnimation(.easeIn(duration: 0.3)) {


### PR DESCRIPTION
## 🎯 Related Issues

***
#### close #321

## ✅ What Did You Do
- [x] 차곡차곡 1줄 클리어 시 추가시간 3초 -> 1초로 하향

***

## 🎸 ETC
- 실수로 브랜치 넘버가 300으로 되어 있으나, 한번 풀을 받고 코드를 수정해서 충돌이 나거나 갑자기 코드가 확 바뀌는 등의 문제는 없습니다.